### PR TITLE
fix: use Buffer to encode basic auth token

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,40 +1,3 @@
-const base64abc = ['A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','0','1','2','3','4','5','6','7','8','9','+','/']
-
-function encode(data: ArrayBuffer | string): string {
-  const uint8 = typeof data === 'string'
-    ? new TextEncoder().encode(data)
-    : data instanceof Uint8Array
-    ? data
-    : new Uint8Array(data)
-
-  let result = ''
-  , i
-
-  const l = uint8.length
-
-  for (i = 2; i < l; i += 3) {
-    result += base64abc[uint8[i - 2] >> 2]
-    result += base64abc[((uint8[i - 2] & 0x03) << 4) | (uint8[i - 1] >> 4)]
-    result += base64abc[((uint8[i - 1] & 0x0f) << 2) | (uint8[i] >> 6)]
-    result += base64abc[uint8[i] & 0x3f]
-  }
-
-  if (i === l + 1) {
-    result += base64abc[uint8[i - 2] >> 2]
-    result += base64abc[(uint8[i - 2] & 0x03) << 4]
-    result += '=='
-  }
-
-  if (i === l) {
-    result += base64abc[uint8[i - 2] >> 2]
-    result += base64abc[((uint8[i - 2] & 0x03) << 4) | (uint8[i - 1] >> 4)]
-    result += base64abc[(uint8[i - 1] & 0x0f) << 2]
-    result += '='
-  }
-
-  return result
-}
-
 export class SMS {
   #token
 
@@ -142,10 +105,12 @@ export class SMS {
      */
     validityPeriod?: number
   }) {
+    const encodedToken = Buffer.from(this.#token + ':').toString('base64')
+
     const res = await fetch('https://gatewayapi.com/rest/mtsms', {
       method: 'POST',
       headers: {
-        Authorization: `Basic ${encode(this.#token + ':')}`,
+        Authorization: `Basic ${encodedToken}`,
         'Content-Type': 'application/json'
       },
       body: JSON.stringify({


### PR DESCRIPTION
## Changed
- Simplified the Base64 encoding

The Base64 encoding was pretty overengineered. I have tested with Node. I see you have a Deno example, and while i haven't tested with Deno, it seems like [Deno supports Buffer.](https://docs.deno.com/runtime/manual/node/compatibility#globals) (but feel free to test, as I don't have any experience with it. 😸)