### PR TITLE
Fix: Scope and fetch

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -36,7 +36,7 @@ function encode(data: ArrayBuffer | string): string {
 }
 
 export class SMS {
-  #token
+  #token: string
 
   constructor(options: {
     token: string

--- a/main.ts
+++ b/main.ts
@@ -44,7 +44,7 @@ export class SMS {
     this.#token = options.token
   }
 
-  async sendMessage(options: {
+  sendMessage = async (options: {
     /**
      * If specified, send status notifications to this URL. Otherwise use the default webhook if set.
      */
@@ -141,7 +141,7 @@ export class SMS {
      * Specified in seconds. If message is not delivered within this timespan, it will expire and you will get a notification. The minimum value is `60`. Every value under 60 will be set to `60`. The default expiry - and maximum - for all messages is 5 days. Some messages might expire before that.
      */
     validityPeriod?: number
-  }) {
+  }) => {
     const res = await fetch('https://gatewayapi.com/rest/mtsms', {
       method: 'POST',
       headers: {

--- a/main.ts
+++ b/main.ts
@@ -183,6 +183,6 @@ export class SMS {
       })
     })
   
-    return res
+    return await res.json()
   }
 }


### PR DESCRIPTION
## Changed
- Made `sendMessage` into an arrow function.
- Added type to #token
- Now awaits the fetch-response from GatewayAPI and extracts the JSON.

The `sendMessage`-method wasn't able to get the token because of scope - it would be undefined. I like arrow functions, but you could also bind `sendMessage` in the constructor. I find this rather messy though.

I also made the return await the fetch response and extract the JSON. Now it correctly returns.